### PR TITLE
Fix to displayHex  logical error

### DIFF
--- a/src/TM1638plus.cpp
+++ b/src/TM1638plus.cpp
@@ -135,6 +135,7 @@ void TM1638plus::displayASCII(uint8_t position, uint8_t ascii) {
 void TM1638plus::displayHex(uint8_t position, uint8_t hex) 
 {
     uint8_t offset = 0;
+    hex = hex % 16;
     if (hex <= 9)
     {
         display7Seg(position, pgm_read_byte(&SevenSeg[hex + TM_HEX_OFFSET]));


### PR DESCRIPTION
By doing a mod on the 'hex' parameter it allows function to properly handle integers past 15.
Fixes https://github.com/gavinlyonsrepo/TM1638plus/issues/18
This has been tested on Arduino UNO and Arduino Mega.  
It works with any integer now and always displays the correct digit.